### PR TITLE
Convert StatefulViewController to an extension

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import StatefulViewController
 
-class ViewController: StatefulViewController {
+class ViewController: UIViewController {
     var dataArray = [String]()
     let refreshControl = UIRefreshControl()
     @IBOutlet weak var tableView: UITableView!
@@ -31,6 +31,8 @@ class ViewController: StatefulViewController {
     
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
+        
+        statefulViewWillAppear()
         
         refresh()
     }


### PR DESCRIPTION
This change allows any subclass of UIViewController to inherit Stateful behavior. So now, your UITableViewControllers and UICollectionViewControllers can easily adopt StatefulViewController behavior.

This is experimental. I'm not a Swift expert, so I'm not 100% sure this is considered a good approach, but at least it does make it easy to extend StatefulViewController to any UIViewController subclass.

The only new requirement is that you must call statefulViewWillAppear() from your view controller's viewWillAppear(animated:) method.

The example app works fine and all the tests pass.

Technical changes and caveats:
- StatefulViewController is defined as an extension, not a subclass of UIViewController.

- Stored properties (which aren't supported by extensions) are implemented via objc_setAssociatedObject.

- The override of viewWillAppear is now a separate function statefulViewWillAppear(), since extensions cannot override functions. Subclasses of UIViewController need to call statefulViewWillAppear() from their viewWillAppear function.

- As an extension, all UIViewControllers now inherit the properties defined by StatefulViewController (currentState, lastState, loadingView, etc.). We might want to change these names to avoid potential name conflicts.


