### PR TITLE
Changes StatefulViewController to a protocol intead of a UIViewController subclass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
-osx_image: xcode6.4
+osx_image: xcode7
 language: objective-c
 script: xctool -scheme StatefulViewControllerTests -sdk iphonesimulator test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+before_install:
+	- brew update
+	- brew install xctool
 osx_image: xcode7
 language: objective-c
 script: xctool -scheme StatefulViewControllerTests -sdk iphonesimulator test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
-before_install:
-	- brew update
-	- brew install xctool
 osx_image: xcode7
 language: objective-c
 script: xctool -scheme StatefulViewControllerTests -sdk iphonesimulator test
+sudo: false
+before_install:
+  - brew update
+  - brew outdated xctool || brew upgrade xctool

--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -469,10 +469,7 @@
 		4D6451611A64079300108EA3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -490,10 +487,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = StatefulViewControllerTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4D64515E1A64079300108EA3 /* StatefulViewController.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4D6451461A64079200108EA3 /* StatefulViewController.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4D6451681A64089800108EA3 /* StatefulViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6451661A64089800108EA3 /* StatefulViewController.swift */; };
 		4D6451691A64089800108EA3 /* ViewStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6451671A64089800108EA3 /* ViewStateMachine.swift */; };
+		4DC230DD1BB5BA810083B95A /* StatefulViewControllerImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC230DC1BB5BA810083B95A /* StatefulViewControllerImplementation.swift */; settings = {ASSET_TAGS = (); }; };
 		4DE62AE219B658610021630A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE62AE119B658610021630A /* AppDelegate.swift */; };
 		4DE62AE419B658610021630A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE62AE319B658610021630A /* ViewController.swift */; };
 		4DE62AE719B658610021630A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4DE62AE519B658610021630A /* Main.storyboard */; };
@@ -73,6 +74,7 @@
 		4D6451591A64079300108EA3 /* StatefulViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatefulViewControllerTests.swift; sourceTree = "<group>"; };
 		4D6451661A64089800108EA3 /* StatefulViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatefulViewController.swift; sourceTree = "<group>"; };
 		4D6451671A64089800108EA3 /* ViewStateMachine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewStateMachine.swift; sourceTree = "<group>"; };
+		4DC230DC1BB5BA810083B95A /* StatefulViewControllerImplementation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatefulViewControllerImplementation.swift; sourceTree = "<group>"; };
 		4DE62ADC19B658610021630A /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4DE62AE019B658610021630A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4DE62AE119B658610021630A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 			isa = PBXGroup;
 			children = (
 				4D6451661A64089800108EA3 /* StatefulViewController.swift */,
+				4DC230DC1BB5BA810083B95A /* StatefulViewControllerImplementation.swift */,
 				4D6451671A64089800108EA3 /* ViewStateMachine.swift */,
 				4D64514A1A64079200108EA3 /* StatefulViewController.h */,
 				4D6451481A64079200108EA3 /* Supporting Files */,
@@ -346,6 +349,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4DC230DD1BB5BA810083B95A /* StatefulViewControllerImplementation.swift in Sources */,
 				4D6451691A64089800108EA3 /* ViewStateMachine.swift in Sources */,
 				4D6451681A64089800108EA3 /* StatefulViewController.swift in Sources */,
 			);

--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -277,7 +277,9 @@
 		4DE62AD419B658610021630A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0600;
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Alexander Schuch";
 				TargetAttributes = {
 					4D6451451A64079200108EA3 = {
@@ -427,6 +429,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.aschuch.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -450,6 +453,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.aschuch.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -472,6 +476,7 @@
 				INFOPLIST_FILE = StatefulViewControllerTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.aschuch.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
@@ -488,6 +493,7 @@
 				INFOPLIST_FILE = StatefulViewControllerTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.aschuch.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
@@ -513,6 +519,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -576,6 +583,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.aschuch.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -586,6 +594,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.aschuch.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Example.xcodeproj/xcshareddata/xcschemes/StatefulViewController.xcscheme
+++ b/Example.xcodeproj/xcshareddata/xcschemes/StatefulViewController.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0620"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,21 +23,24 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -52,10 +55,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Example.xcodeproj/xcshareddata/xcschemes/StatefulViewControllerTests.xcscheme
+++ b/Example.xcodeproj/xcshareddata/xcschemes/StatefulViewControllerTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -48,15 +48,18 @@
             ReferencedContainer = "container:Example.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -71,20 +74,11 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4D64514F1A64079200108EA3"
-            BuildableName = "StatefulViewControllerTests.xctest"
-            BlueprintName = "StatefulViewControllerTests"
-            ReferencedContainer = "container:Example.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.aschuch.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Example/PlaceholderViews/BasicPlaceholderView.swift
+++ b/Example/PlaceholderViews/BasicPlaceholderView.swift
@@ -18,7 +18,7 @@ class BasicPlaceholderView: UIView {
 		setupView()
 	}
 	
-	required init(coder aDecoder: NSCoder) {
+	required init?(coder aDecoder: NSCoder) {
 		super.init(coder: aDecoder)
 		
 		setupView()
@@ -27,7 +27,7 @@ class BasicPlaceholderView: UIView {
 	func setupView() {
 		backgroundColor = UIColor.whiteColor()
 		
-		centerView.setTranslatesAutoresizingMaskIntoConstraints(false)
+		centerView.translatesAutoresizingMaskIntoConstraints = false
 		self.addSubview(centerView)
 		
 		let views = ["centerView": centerView, "superview": self]

--- a/Example/PlaceholderViews/EmptyView.swift
+++ b/Example/PlaceholderViews/EmptyView.swift
@@ -18,7 +18,7 @@ class EmptyView: BasicPlaceholderView {
 		backgroundColor = UIColor.whiteColor()
 		
 		label.text = "No Content."
-		label.setTranslatesAutoresizingMaskIntoConstraints(false)
+		label.translatesAutoresizingMaskIntoConstraints = false
 		centerView.addSubview(label)
 		
 		let views = ["label": label]

--- a/Example/PlaceholderViews/ErrorView.swift
+++ b/Example/PlaceholderViews/ErrorView.swift
@@ -22,7 +22,7 @@ class ErrorView: BasicPlaceholderView {
 		self.addGestureRecognizer(tapGestureRecognizer)
 		
 		textLabel.text = "Something went wrong."
-		textLabel.setTranslatesAutoresizingMaskIntoConstraints(false)
+		textLabel.translatesAutoresizingMaskIntoConstraints = false
 		centerView.addSubview(textLabel)
 		
 		detailTextLabel.text = "Tap to reload"
@@ -30,7 +30,7 @@ class ErrorView: BasicPlaceholderView {
 		detailTextLabel.font = UIFont(descriptor: fontDescriptor, size: 0)
 		detailTextLabel.textAlignment = .Center
 		detailTextLabel.textColor = UIColor.grayColor()
-		detailTextLabel.setTranslatesAutoresizingMaskIntoConstraints(false)
+		detailTextLabel.translatesAutoresizingMaskIntoConstraints = false
 		centerView.addSubview(detailTextLabel)
 		
 		let views = ["label": textLabel, "detailLabel": detailTextLabel]

--- a/Example/PlaceholderViews/LoadingView.swift
+++ b/Example/PlaceholderViews/LoadingView.swift
@@ -18,18 +18,18 @@ class LoadingView: BasicPlaceholderView {
 		backgroundColor = UIColor.whiteColor()
 		
 		label.text = "Loading..."
-		label.setTranslatesAutoresizingMaskIntoConstraints(false)
+		label.translatesAutoresizingMaskIntoConstraints = false
 		centerView.addSubview(label)
 		
 		let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .Gray)
 		activityIndicator.startAnimating()
-		activityIndicator.setTranslatesAutoresizingMaskIntoConstraints(false)
+		activityIndicator.translatesAutoresizingMaskIntoConstraints = false
 		centerView.addSubview(activityIndicator)
 		
 		let views = ["label": label, "activity": activityIndicator]
-		let hConstraints = NSLayoutConstraint.constraintsWithVisualFormat("|-[activity]-[label]-|", options: nil, metrics: nil, views: views)
-		let vConstraintsLabel = NSLayoutConstraint.constraintsWithVisualFormat("V:|[label]|", options: nil, metrics: nil, views: views)
-		let vConstraintsActivity = NSLayoutConstraint.constraintsWithVisualFormat("V:|[activity]|", options: nil, metrics: nil, views: views)
+		let hConstraints = NSLayoutConstraint.constraintsWithVisualFormat("|-[activity]-[label]-|", options: [], metrics: nil, views: views)
+		let vConstraintsLabel = NSLayoutConstraint.constraintsWithVisualFormat("V:|[label]|", options: [], metrics: nil, views: views)
+		let vConstraintsActivity = NSLayoutConstraint.constraintsWithVisualFormat("V:|[activity]|", options: [], metrics: nil, views: views)
 
 		centerView.addConstraints(hConstraints)
 		centerView.addConstraints(vConstraintsLabel)

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -39,9 +39,9 @@ class ViewController: StatefulViewController {
         if (lastState == .Loading) { return }
         
         startLoading(completion: {
-            println("completaion startLoading -> loadingState: \(self.currentState.rawValue)")
+            print("completaion startLoading -> loadingState: \(self.currentState.rawValue)")
         })
-        println("startLoading -> loadingState: \(self.lastState.rawValue)")
+        print("startLoading -> loadingState: \(self.lastState.rawValue)")
         
         // Fake network call
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(3 * Double(NSEC_PER_SEC))), dispatch_get_main_queue()) {
@@ -49,9 +49,9 @@ class ViewController: StatefulViewController {
             self.dataArray = ["Merlot", "Sauvignon Blanc", "Blaufränkisch", "Pinot Nior"]
             self.tableView.reloadData()
             self.endLoading(error: nil, completion: {
-                println("completion endLoading -> loadingState: \(self.currentState.rawValue)")
+                print("completion endLoading -> loadingState: \(self.currentState.rawValue)")
             })
-            println("endLoading -> loadingState: \(self.lastState.rawValue)")
+            print("endLoading -> loadingState: \(self.lastState.rawValue)")
             
             // Error
             //self.endLoading(error: NSError())
@@ -67,7 +67,7 @@ class ViewController: StatefulViewController {
 
 extension ViewController: StatefulViewControllerDelegate {
     func hasContent() -> Bool {
-        return count(dataArray) > 0
+        return dataArray.count > 0
     }
     
     func handleErrorWhenContentAvailable(error: NSError) {
@@ -80,11 +80,11 @@ extension ViewController: StatefulViewControllerDelegate {
 extension ViewController: UITableViewDataSource {
     
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return count(dataArray)
+        return dataArray.count
     }
     
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier("textCell", forIndexPath: indexPath) as! UITableViewCell
+        let cell = tableView.dequeueReusableCellWithIdentifier("textCell", forIndexPath: indexPath) 
         cell.textLabel?.text = dataArray[indexPath.row]
         return cell
     }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import StatefulViewController
 
-class ViewController: StatefulViewController {
+class ViewController: UIViewController, StatefulViewController {
     var dataArray = [String]()
     let refreshControl = UIRefreshControl()
     @IBOutlet weak var tableView: UITableView!
@@ -32,6 +32,7 @@ class ViewController: StatefulViewController {
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         
+        setupInitialViewState()
         refresh()
     }
     
@@ -54,7 +55,7 @@ class ViewController: StatefulViewController {
             print("endLoading -> loadingState: \(self.lastState.rawValue)")
             
             // Error
-            //self.endLoading(error: NSError())
+            //self.endLoading(error: NSError(domain: "foo", code: -1, userInfo: nil))
             
             // No Content
             //self.endLoading(error: nil)
@@ -65,17 +66,21 @@ class ViewController: StatefulViewController {
     
 }
 
-extension ViewController: StatefulViewControllerDelegate {
+
+extension ViewController {
+    
     func hasContent() -> Bool {
         return dataArray.count > 0
     }
     
-    func handleErrorWhenContentAvailable(error: NSError) {
+    func handleErrorWhenContentAvailable(error: ErrorType) {
         let alertController = UIAlertController(title: "Ooops", message: "Something went wrong.", preferredStyle: .Alert)
         alertController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil))
         self.presentViewController(alertController, animated: true, completion: nil)
     }
+    
 }
+
 
 extension ViewController: UITableViewDataSource {
     

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Build Status](https://travis-ci.org/aschuch/StatefulViewController.svg)](https://travis-ci.org/aschuch/StatefulViewController)
 ![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)
 
-A view controller subclass that presents placeholder views based on content, loading, error or empty states.
+A protocol to enable `UIViewController`s or `UIView`s to present placeholder views based on content, loading, error or empty states.
 
 ![StatefulViewController Example](Resources/example.gif)
 
-In a networked application a view controller typically has the following states that need to be communicated to the user:
+In a networked application a view controller or custom view typically has the following states that need to be communicated to the user:
 
 * **Loading**: The content is currently loaded over the network.
 * **Content**: The content is available and presented to the user.
@@ -18,17 +18,47 @@ As trivial as this flow may sound, there are a lot of cases that result in a rat
 
 ![Decision Tree](Resources/decision_tree.png)
 
-StatefulViewController is a concrete implementation of this particular decision tree. (If you want to create your own modified version, you might be interested in the [state machine](#viewstatemachine) that is used to show and hide views.)
+`StatefulViewController` is a concrete implementation of this particular decision tree. (If you want to create your own modified version, you might be interested in the [state machine](#viewstatemachine) that is used to show and hide views.)
 
 ## Usage
+> This guide describes the use of the `StatefulViewController` protocol on `UIViewController`. However, you can also adopt the `StatefulViewController` protocol on any `UIViewController` subclass, such as `UITableViewController` or `UICollectionViewController`, as well as your custom `UIView` subclasses.
 
-Configure the `loadingView`, `emptyView` and `errorView` properties of your `StatefulViewController` subclass in `viewDidLoad`.
+First, make sure your view controller adopts to the `StatefulViewController` protocol. 
 
-After that, simply tell the view controller if content is currently being loaded and it will take care of showing and hiding the correct loading, error and empty view for you.
+```swift 
+class MyViewController: UIViewController, StatefulViewController {
+    // ...
+}
+``` 
+
+Then, configure the `loadingView`, `emptyView` and `errorView` properties (provided by the `StatefulViewController` protocol) in `viewDidLoad`.
+
+```swift
+override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    // Setup placeholder views
+    loadingView = // UIView
+    emptyView = // UIView
+    errorView = // UIView
+}
+```
+
+In addition, call the `setupInitialViewState()` method in `viewWillAppear:` in order to setup the initial state of the controller.
 
 ```swift
 override func viewWillAppear(animated: Bool) {
-	super.viewWillAppear(animated)
+    super.viewWillAppear(animated)
+        
+    setupInitialViewState()
+}
+```
+
+After that, simply tell the view controller whenever content is loading and `StatefulViewController` will take care of showing and hiding the correct loading, error and empty view for you.
+
+```swift
+override func viewWillAppear(animated: Bool) {
+    super.viewWillAppear(animated)
         
     loadDeliciousWines()
 }
@@ -38,27 +68,28 @@ func loadDeliciousWines() {
 	
 	let url = NSURL(string: "http://example.com/api")
 	let session = NSURLSession.sharedSession()
-	let task = session.dataTaskWithURL(url) { (let data, let response, let error) in
+	session.dataTaskWithURL(url) { (let data, let response, let error) in
 		endLoading(error: error)
-	}
-	task.resume()
+	}.resume()
 }
 ```
 
-### StatefulViewControllerDelegate
+### Life cycle
 
-StatefulViewController calls the `hasContent` delegate method to check if there is any content to display. If you do not implement this protocol, StatefulViewController will always assume that there is content to display.
+StatefulViewController calls the `hasContent` method to check if there is any content to display. If you do not override this method in your own class, `StatefulViewController` will always assume that there is content to display.
 
 ```swift
 func hasContent() -> Bool {
-	return countElements(datasourceArray) > 0
+	return datasourceArray.count > 0
 }
 ```
 
-Optionally, you might also be interested to respond to an error even if content is already shown. In this case, use `handleErrorWhenContentAvailable` to manually present the error to the user.
+Optionally, you might also be interested to respond to an error even if content is already shown. `StatefulViewController` will not show its `errorView` in this case, because there is already content that can be shown.
+
+To e.g. show a custom alert or other unobtrusive error message, use `handleErrorWhenContentAvailable:` to manually present the error to the user.
 
 ```swift
-func handleErrorWhenContentAvailable(error: NSError) {
+func handleErrorWhenContentAvailable(error: ErrorType) {
 	let alertController = UIAlertController(title: "Ooops", message: "Something went wrong.", preferredStyle: .Alert)
 	alertController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil))
 	self.presentViewController(alertController, animated: true, completion: nil)

--- a/README.md
+++ b/README.md
@@ -123,26 +123,22 @@ stateMachine.transitionToState(.None, animated: true) {
 
 ## Installation
 
-The master branch of AwesomeCache is ready for swift 1.2. In case you are still on 1.1, please refer to the `swift-1.1` tag.
-
 #### Carthage
 
 Add the following line to your [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile).
 
 ```
-github "aschuch/StatefulViewController"
+github "aschuch/StatefulViewController", ~> 2.0
 ```
 
 Then run `carthage update`.
 
 #### Cocoapods
 
-**NOTE:** Cocoapods does not officially support Swift projects yet.  Make sure you have Cocoapods 0.36 beta installed by running `gem install cocoapods --pre`.
-
 Add the following line to your Podfile.
 
 ```
-pod "StatefulViewController", "~> 0.1"
+pod "StatefulViewController", "~> 2.0"
 ```
 
 Then run `pod install` with Cocoapods 0.36 or newer.

--- a/StatefulViewController/Info.plist
+++ b/StatefulViewController/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.aschuch.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/StatefulViewController/StatefulViewController.swift
+++ b/StatefulViewController/StatefulViewController.swift
@@ -1,14 +1,6 @@
-//
-//  StatefulViewController.swift
-//  StatefulViewController
-//
-//  Created by Alexander Schuch on 30/07/14.
-//  Copyright (c) 2014 Alexander Schuch. All rights reserved.
-//
-
 import UIKit
 
-/// Represents all possible states of this view controller
+/// Represents all possible states of a stateful view controller
 public enum StatefulViewControllerState: String {
     case Content = "content"
     case Loading = "loading"
@@ -16,85 +8,53 @@ public enum StatefulViewControllerState: String {
     case Empty = "empty"
 }
 
-/// Delegate protocol
-@objc public protocol StatefulViewControllerDelegate {
-    /// Return true if content is available in your controller.
-    ///
-    /// - returns: true if there is content available in your controller.
-    ///
-    func hasContent() -> Bool
-    
-    /// This method is called if an error occured, but `hasContent` returned true.
-    /// You would typically display an unobstrusive error message that is easily dismissable
-    /// for the user to continue browsing content.
-    ///
-    /// - parameter error:	The error that occured
-    ///
-    optional func handleErrorWhenContentAvailable(error: NSError)
+/// Protocol to provide a backing view for that stateful view controller
+public protocol BackingViewProvider {
+    /// The backing view, usually a UIViewController's view.
+    /// All placeholder views will be added to this view instance.
+    var backingView: UIView { get }
 }
 
-///
-/// A view controller subclass that presents placeholder views based on content, loading, error or empty states.
-///
-public class StatefulViewController: UIViewController {
-    lazy private var stateMachine: ViewStateMachine = ViewStateMachine(view: self.view)
-    
-    /// The current state of the view controller.
+/// StatefulViewController protocol may be adopted by a view controller or a view in order to transition to
+/// error, loading or empty views.
+public protocol StatefulViewController: class, BackingViewProvider {
+    /// The view state machine backing all state transitions
+    var stateMachine: ViewStateMachine { get }
+
+    /// The current transition state of the view controller.
     /// All states other than `Content` imply that there is a placeholder view shown.
-    public var currentState: StatefulViewControllerState {
-        switch stateMachine.currentState {
-        case .None: return .Content
-        case .View(let viewKey): return StatefulViewControllerState(rawValue: viewKey)!
-        }
-    }
+    var currentState: StatefulViewControllerState { get }
     
-    public var lastState: StatefulViewControllerState {
-        switch stateMachine.lastState {
-        case .None: return .Content
-        case .View(let viewKey): return StatefulViewControllerState(rawValue: viewKey)!
-        }
-    }
+    /// The last transition state that was sent to the state machine for execution.
+    /// This does not imply that the state is currently shown on screen. Transitions are queued up and 
+    /// executed in sequential order.
+    var lastState: StatefulViewControllerState { get }
+    
     
     // MARK: Views
     
     /// The loading view is shown when the `startLoading` method gets called
-    public var loadingView: UIView! {
-        didSet { setPlaceholderView(loadingView, forState: .Loading) }
-    }
+    var loadingView: UIView? { get set }
     
     /// The error view is shown when the `endLoading` method returns an error
-    public var errorView: UIView! {
-        didSet { setPlaceholderView(errorView, forState: .Error) }
-    }
+    var errorView: UIView? { get set }
     
     /// The empty view is shown when the `hasContent` method returns false
-    public var emptyView: UIView! {
-        didSet { setPlaceholderView(emptyView, forState: .Empty) }
-    }
+    var emptyView: UIView? { get set }
+
     
-    
-    // MARK: UIViewController
-    
-    override public func viewWillAppear(animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        // Make sure to stay in the correct state when transitioning
-        let isLoading = (lastState == .Loading)
-        let error: NSError? = (lastState == .Error) ? NSError(domain: "com.aschuch.StatefulViewController.ErrorDomain", code: -1, userInfo: nil) : nil
-        transitionViewStates(isLoading, error: error, animated: false)
-    }
-    
-    
-    // MARK: Start and stop loading
+    // MARK: Transitions
+
+    /// Sets up the initial state of the view.
+    /// This method should be called as soon as possible in a view or view controller's
+    /// life cycle, e.g. `viewWillAppear:`, to transition to the appropriate state.
+    func setupInitialViewState()
     
     /// Transitions the controller to the loading state and shows
     /// the loading view if there is no content shown already.
     ///
     /// - parameter animated: 	true if the switch to the placeholder view should be animated, false otherwise
-    ///
-    public func startLoading(animated: Bool = false, completion: (() -> ())? = nil) {
-        transitionViewStates(true, animated: animated, completion: completion)
-    }
+    func startLoading(animated: Bool, completion: (() -> Void)?)
     
     /// Ends the controller's loading state.
     /// If an error occured, the error view is shown.
@@ -102,13 +62,7 @@ public class StatefulViewController: UIViewController {
     ///
     /// - parameter animated: 	true if the switch to the placeholder view should be animated, false otherwise
     /// - parameter error:		An error that might have occured whilst loading
-    ///
-    public func endLoading(animated: Bool = true, error: NSError? = nil, completion: (() -> ())? = nil) {
-        transitionViewStates(false, animated: animated, error: error, completion: completion)
-    }
-    
-    
-    // MARK: Update view states
+    func endLoading(animated: Bool, error: ErrorType?, completion: (() -> Void)?)
     
     /// Transitions the view to the appropriate state based on the `loading` and `error`
     /// input parameters and shows/hides corresponding placeholder views.
@@ -116,34 +70,20 @@ public class StatefulViewController: UIViewController {
     /// - parameter loading:		true if the controller is currently loading
     /// - parameter error:		An error that might have occured whilst loading
     /// - parameter animated:	true if the switch to the placeholder view should be animated, false otherwise
+    func transitionViewStates(loading: Bool, error: ErrorType?, animated: Bool, completion: (() -> Void)?)
+    
+    
+    // MARK: Content and error handling
+    
+    /// Return true if content is available in your controller.
     ///
-    public func transitionViewStates(loading: Bool = false, error: NSError? = nil, animated: Bool = true, completion: (() -> ())? = nil) {
-        let hasContent = (self as? StatefulViewControllerDelegate)?.hasContent() ?? true
-        
-        // Update view for content (i.e. hide all placeholder views)
-        if hasContent {
-            if let e = error {
-                // show unobstrusive error
-                (self as? StatefulViewControllerDelegate)?.handleErrorWhenContentAvailable?(e)
-            }
-            self.stateMachine.transitionToState(.None, animated: animated, completion: completion)
-            return
-        }
-        
-        // Update view for placeholder
-        var newState: StatefulViewControllerState = .Empty
-        if loading {
-            newState = .Loading
-        } else if let _ = error {
-            newState = .Error
-        }
-        self.stateMachine.transitionToState(.View(newState.rawValue), animated: animated, completion: completion)
-    }
+    /// - returns: true if there is content available in your controller.
+    func hasContent() -> Bool
     
-    
-    // MARK: Helper
-    
-    private func setPlaceholderView(view: UIView, forState state: StatefulViewControllerState) {
-        stateMachine[state.rawValue] = view
-    }
+    /// This method is called if an error occured, but `hasContent` returned true.
+    /// You would typically display an unobstrusive error message that is easily dismissable
+    /// for the user to continue browsing content.
+    ///
+    /// - parameter error:	The error that occured
+    func handleErrorWhenContentAvailable(error: ErrorType)
 }

--- a/StatefulViewController/StatefulViewController.swift
+++ b/StatefulViewController/StatefulViewController.swift
@@ -20,7 +20,7 @@ public enum StatefulViewControllerState: String {
 @objc public protocol StatefulViewControllerDelegate {
     /// Return true if content is available in your controller.
     ///
-    /// :returns: true if there is content available in your controller.
+    /// - returns: true if there is content available in your controller.
     ///
     func hasContent() -> Bool
     
@@ -28,7 +28,7 @@ public enum StatefulViewControllerState: String {
     /// You would typically display an unobstrusive error message that is easily dismissable
     /// for the user to continue browsing content.
     ///
-    /// :param: error	The error that occured
+    /// - parameter error:	The error that occured
     ///
     optional func handleErrorWhenContentAvailable(error: NSError)
 }
@@ -80,8 +80,8 @@ public class StatefulViewController: UIViewController {
         
         // Make sure to stay in the correct state when transitioning
         let isLoading = (lastState == .Loading)
-        let error: NSError? = (lastState == .Error) ? NSError() : nil
-        transitionViewStates(loading: isLoading, error: error, animated: false)
+        let error: NSError? = (lastState == .Error) ? NSError(domain: "com.aschuch.StatefulViewController.ErrorDomain", code: -1, userInfo: nil) : nil
+        transitionViewStates(isLoading, error: error, animated: false)
     }
     
     
@@ -90,21 +90,21 @@ public class StatefulViewController: UIViewController {
     /// Transitions the controller to the loading state and shows
     /// the loading view if there is no content shown already.
     ///
-    /// :param: animated 	true if the switch to the placeholder view should be animated, false otherwise
+    /// - parameter animated: 	true if the switch to the placeholder view should be animated, false otherwise
     ///
     public func startLoading(animated: Bool = false, completion: (() -> ())? = nil) {
-        transitionViewStates(loading: true, animated: animated, completion: completion)
+        transitionViewStates(true, animated: animated, completion: completion)
     }
     
     /// Ends the controller's loading state.
     /// If an error occured, the error view is shown.
     /// If the `hasContent` method returns false after calling this method, the empty view is shown.
     ///
-    /// :param: animated 	true if the switch to the placeholder view should be animated, false otherwise
-    /// :param: error		An error that might have occured whilst loading
+    /// - parameter animated: 	true if the switch to the placeholder view should be animated, false otherwise
+    /// - parameter error:		An error that might have occured whilst loading
     ///
     public func endLoading(animated: Bool = true, error: NSError? = nil, completion: (() -> ())? = nil) {
-        transitionViewStates(loading: false, animated: animated, error: error, completion: completion)
+        transitionViewStates(false, animated: animated, error: error, completion: completion)
     }
     
     
@@ -113,9 +113,9 @@ public class StatefulViewController: UIViewController {
     /// Transitions the view to the appropriate state based on the `loading` and `error`
     /// input parameters and shows/hides corresponding placeholder views.
     ///
-    /// :param: loading		true if the controller is currently loading
-    /// :param: error		An error that might have occured whilst loading
-    /// :param: animated	true if the switch to the placeholder view should be animated, false otherwise
+    /// - parameter loading:		true if the controller is currently loading
+    /// - parameter error:		An error that might have occured whilst loading
+    /// - parameter animated:	true if the switch to the placeholder view should be animated, false otherwise
     ///
     public func transitionViewStates(loading: Bool = false, error: NSError? = nil, animated: Bool = true, completion: (() -> ())? = nil) {
         let hasContent = (self as? StatefulViewControllerDelegate)?.hasContent() ?? true
@@ -134,7 +134,7 @@ public class StatefulViewController: UIViewController {
         var newState: StatefulViewControllerState = .Empty
         if loading {
             newState = .Loading
-        } else if let e = error {
+        } else if let _ = error {
             newState = .Error
         }
         self.stateMachine.transitionToState(.View(newState.rawValue), animated: animated, completion: completion)

--- a/StatefulViewController/StatefulViewControllerImplementation.swift
+++ b/StatefulViewController/StatefulViewControllerImplementation.swift
@@ -100,11 +100,11 @@ extension StatefulViewController {
     
     // MARK: Content and error handling
     
-    func hasContent() -> Bool {
+    public func hasContent() -> Bool {
         return true
     }
     
-    func handleErrorWhenContentAvailable(error: ErrorType) {
+    public func handleErrorWhenContentAvailable(error: ErrorType) {
         // Default implementation does nothing.
     }
     

--- a/StatefulViewController/StatefulViewControllerImplementation.swift
+++ b/StatefulViewController/StatefulViewControllerImplementation.swift
@@ -1,0 +1,135 @@
+import UIKit
+
+
+// MARK: Default Implementation BackingViewProvider
+
+extension BackingViewProvider where Self: UIViewController {
+    public var backingView: UIView {
+        return view
+    }
+}
+
+extension BackingViewProvider where Self: UIView {
+    public var backingView: UIView {
+        return self
+    }
+}
+
+
+// MARK: Default Implementation StatefulViewController
+
+/// Default implementation of StatefulViewController for UIViewController
+extension StatefulViewController {
+    
+    public var stateMachine: ViewStateMachine {
+        return associatedObject(self, key: &stateMachineKey) { [unowned self] in
+            return ViewStateMachine(view: self.backingView)
+        }
+    }
+    
+    public var currentState: StatefulViewControllerState {
+        switch stateMachine.currentState {
+        case .None: return .Content
+        case .View(let viewKey): return StatefulViewControllerState(rawValue: viewKey)!
+        }
+    }
+    
+    public var lastState: StatefulViewControllerState {
+        switch stateMachine.lastState {
+        case .None: return .Content
+        case .View(let viewKey): return StatefulViewControllerState(rawValue: viewKey)!
+        }
+    }
+    
+    
+    // MARK: Views
+    
+    public var loadingView: UIView? {
+        get { return placeholderView(.Loading) }
+        set { setPlaceholderView(newValue, forState: .Loading) }
+    }
+    
+    public var errorView: UIView? {
+        get { return placeholderView(.Error) }
+        set { setPlaceholderView(newValue, forState: .Error) }
+    }
+    
+    public var emptyView: UIView? {
+        get { return placeholderView(.Empty) }
+        set { setPlaceholderView(newValue, forState: .Empty) }
+    }
+    
+    
+    // MARK: Transitions
+    
+    public func setupInitialViewState() {
+        let isLoading = (lastState == .Loading)
+        let error: NSError? = (lastState == .Error) ? NSError(domain: "com.aschuch.StatefulViewController.ErrorDomain", code: -1, userInfo: nil) : nil
+        transitionViewStates(isLoading, error: error, animated: false)
+    }
+    
+    public func startLoading(animated: Bool = false, completion: (() -> Void)? = nil) {
+        transitionViewStates(true, animated: animated, completion: completion)
+    }
+    
+    public func endLoading(animated: Bool = true, error: ErrorType? = nil, completion: (() -> Void)? = nil) {
+        transitionViewStates(false, animated: animated, error: error, completion: completion)
+    }
+    
+    public func transitionViewStates(loading: Bool = false, error: ErrorType? = nil, animated: Bool = true, completion: (() -> Void)? = nil) {
+        // Update view for content (i.e. hide all placeholder views)
+        if hasContent() {
+            if let e = error {
+                // show unobstrusive error
+                handleErrorWhenContentAvailable(e)
+            }
+            self.stateMachine.transitionToState(.None, animated: animated, completion: completion)
+            return
+        }
+        
+        // Update view for placeholder
+        var newState: StatefulViewControllerState = .Empty
+        if loading {
+            newState = .Loading
+        } else if let _ = error {
+            newState = .Error
+        }
+        self.stateMachine.transitionToState(.View(newState.rawValue), animated: animated, completion: completion)
+    }
+    
+    
+    // MARK: Content and error handling
+    
+    func hasContent() -> Bool {
+        return true
+    }
+    
+    func handleErrorWhenContentAvailable(error: ErrorType) {
+        // Default implementation does nothing.
+    }
+    
+    
+    // MARK: Helper
+    
+    private func placeholderView(state: StatefulViewControllerState) -> UIView? {
+        return stateMachine[state.rawValue]
+    }
+    
+    private func setPlaceholderView(view: UIView?, forState state: StatefulViewControllerState) {
+        stateMachine[state.rawValue] = view
+    }
+}
+
+
+// MARK: Association
+
+private var stateMachineKey: UInt8 = 0
+
+private func associatedObject<T: AnyObject>(host: AnyObject, key: UnsafePointer<Void>, initial: () -> T) -> T {
+    var value = objc_getAssociatedObject(host, key) as? T
+    if value == nil {
+        value = initial()
+        objc_setAssociatedObject(host, key, value, .OBJC_ASSOCIATION_RETAIN)
+    }
+    return value!
+}

--- a/StatefulViewController/ViewStateMachine.swift
+++ b/StatefulViewController/ViewStateMachine.swift
@@ -49,19 +49,19 @@ public class ViewStateMachine {
     
     ///  Designated initializer.
     ///
-    /// :param: view		The view that should act as the superview for any added views
-    /// :param: states		A dictionary of states
+    /// - parameter view:		The view that should act as the superview for any added views
+    /// - parameter states:		A dictionary of states
     ///
-    /// :returns:			A view state machine with the given views for states
+    /// - returns:			A view state machine with the given views for states
     ///
     public init(view: UIView, states: [String: UIView]?) {
         self.view = view
         viewStore = states ?? [String: UIView]()
     }
     
-    /// :param: view		The view that should act as the superview for any added views
+    /// - parameter view:		The view that should act as the superview for any added views
     ///
-    /// :returns:			A view state machine
+    /// - returns:			A view state machine
     ///
     public convenience init(view: UIView) {
         self.init(view: view, states: nil)
@@ -70,7 +70,7 @@ public class ViewStateMachine {
     
     // MARK: Add and remove view states
     
-    /// :returns: the view for a given state
+    /// - returns: the view for a given state
     public func viewForState(state: String) -> UIView? {
         return viewStore[state]
     }
@@ -107,9 +107,9 @@ public class ViewStateMachine {
     /// Adds and removes views to and from the `view` based on the given state.
     /// Animations are synchronized in order to make sure that there aren't any animation gliches in the UI
     ///
-    /// :param: state		The state to transition to
-    /// :param: animated	true if the transition should fade views in and out
-    /// :param: campletion	called when all animations are finished and the view has been updated
+    /// - parameter state:		The state to transition to
+    /// - parameter animated:	true if the transition should fade views in and out
+    /// - parameter campletion:	called when all animations are finished and the view has been updated
     ///
     public func transitionToState(state: ViewStateMachineState, animated: Bool = true, completion: (() -> ())? = nil) {
         lastState = state
@@ -147,12 +147,12 @@ public class ViewStateMachine {
         if let newView = self.viewStore[state] {
             // Add new view using AutoLayout
             newView.alpha = animated ? 0.0 : 1.0
-            newView.setTranslatesAutoresizingMaskIntoConstraints(false)
+            newView.translatesAutoresizingMaskIntoConstraints = false
             self.view.addSubview(newView)
             
             let views = ["view": newView]
-            let hConstraints = NSLayoutConstraint.constraintsWithVisualFormat("|[view]|", options: nil, metrics: nil, views: views)
-            let vConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options: nil, metrics: nil, views: views)
+            let hConstraints = NSLayoutConstraint.constraintsWithVisualFormat("|[view]|", options: [], metrics: nil, views: views)
+            let vConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options: [], metrics: nil, views: views)
             self.view.addConstraints(hConstraints)
             self.view.addConstraints(vConstraints)
         }
@@ -176,7 +176,7 @@ public class ViewStateMachine {
         animateChanges(animated: animated, animations: animations, animationCompletion: animationCompletion)
     }
     
-    private func hideAllViews(#animated: Bool, completion: (() -> ())? = nil) {
+    private func hideAllViews(animated animated: Bool, completion: (() -> ())? = nil) {
         let animations: () -> () = {
             for (_, view) in self.viewStore {
                 view.alpha = 0.0
@@ -194,7 +194,7 @@ public class ViewStateMachine {
         animateChanges(animated: animated, animations: animations, animationCompletion: animationCompletion)
     }
     
-    private func animateChanges(#animated: Bool, animations: () -> (), animationCompletion: (Bool) -> ()) {
+    private func animateChanges(animated animated: Bool, animations: () -> (), animationCompletion: (Bool) -> ()) {
         if animated {
             UIView.animateWithDuration(0.3, animations: animations, completion: animationCompletion)
         } else {

--- a/StatefulViewControllerTests/Info.plist
+++ b/StatefulViewControllerTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.aschuch.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
* StatefulViewController is now defined as a generic protocol, with default implementations for UIViewController and UIView. This is a major (breaking) change that makes it possible to also adopt StatefulViewController for `UITableViewController` and `UICollectionViewController` subclasses. Closes #3 and #8.
* Updates to new Swift 2.0 syntax (closes #9)
* Updates the Readme to reflect the new changes
