### PR TITLE
Insets for State Views

### DIFF
--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		4D64515E1A64079300108EA3 /* StatefulViewController.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4D6451461A64079200108EA3 /* StatefulViewController.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4D6451681A64089800108EA3 /* StatefulViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6451661A64089800108EA3 /* StatefulViewController.swift */; };
 		4D6451691A64089800108EA3 /* ViewStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6451671A64089800108EA3 /* ViewStateMachine.swift */; };
-		4DC230DD1BB5BA810083B95A /* StatefulViewControllerImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC230DC1BB5BA810083B95A /* StatefulViewControllerImplementation.swift */; settings = {ASSET_TAGS = (); }; };
+		4DC230DD1BB5BA810083B95A /* StatefulViewControllerImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC230DC1BB5BA810083B95A /* StatefulViewControllerImplementation.swift */; };
 		4DE62AE219B658610021630A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE62AE119B658610021630A /* AppDelegate.swift */; };
 		4DE62AE419B658610021630A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE62AE319B658610021630A /* ViewController.swift */; };
 		4DE62AE719B658610021630A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4DE62AE519B658610021630A /* Main.storyboard */; };
@@ -72,9 +72,9 @@
 		4D6451501A64079200108EA3 /* StatefulViewControllerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StatefulViewControllerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D6451581A64079300108EA3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4D6451591A64079300108EA3 /* StatefulViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatefulViewControllerTests.swift; sourceTree = "<group>"; };
-		4D6451661A64089800108EA3 /* StatefulViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatefulViewController.swift; sourceTree = "<group>"; };
-		4D6451671A64089800108EA3 /* ViewStateMachine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewStateMachine.swift; sourceTree = "<group>"; };
-		4DC230DC1BB5BA810083B95A /* StatefulViewControllerImplementation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatefulViewControllerImplementation.swift; sourceTree = "<group>"; };
+		4D6451661A64089800108EA3 /* StatefulViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = StatefulViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
+		4D6451671A64089800108EA3 /* ViewStateMachine.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = ViewStateMachine.swift; sourceTree = "<group>"; tabWidth = 4; };
+		4DC230DC1BB5BA810083B95A /* StatefulViewControllerImplementation.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = StatefulViewControllerImplementation.swift; sourceTree = "<group>"; tabWidth = 4; };
 		4DE62ADC19B658610021630A /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4DE62AE019B658610021630A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4DE62AE119B658610021630A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -13,7 +13,8 @@ class ViewController: UIViewController, StatefulViewController {
     var dataArray = [String]()
     let refreshControl = UIRefreshControl()
     @IBOutlet weak var tableView: UITableView!
-    
+
+  var stateInsets: UIEdgeInsets = UIEdgeInsets(top: 60, left: 20, bottom: 0, right: 0)
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/StatefulViewController/StatefulViewController.swift
+++ b/StatefulViewController/StatefulViewController.swift
@@ -42,7 +42,7 @@ public protocol StatefulViewController: class, BackingViewProvider {
     /// The empty view is shown when the `hasContent` method returns false
     var emptyView: UIView? { get set }
 
-    var stateInsets: UIEdgeInsets { get set }
+    var stateInsets: UIEdgeInsets { get }
 
     
     // MARK: Transitions

--- a/StatefulViewController/StatefulViewController.swift
+++ b/StatefulViewController/StatefulViewController.swift
@@ -42,6 +42,8 @@ public protocol StatefulViewController: class, BackingViewProvider {
     /// The empty view is shown when the `hasContent` method returns false
     var emptyView: UIView? { get set }
 
+    var stateInsets: UIEdgeInsets { get set }
+
     
     // MARK: Transitions
 

--- a/StatefulViewController/StatefulViewControllerImplementation.swift
+++ b/StatefulViewController/StatefulViewControllerImplementation.swift
@@ -82,6 +82,7 @@ extension StatefulViewController {
     }
     
     public func transitionViewStates(loading: Bool = false, error: ErrorType? = nil, animated: Bool = true, completion: (() -> Void)? = nil) {
+        self.stateMachine.insets = self.stateInsets
         // Update view for content (i.e. hide all placeholder views)
         if hasContent() {
             if let e = error {

--- a/StatefulViewController/StatefulViewControllerImplementation.swift
+++ b/StatefulViewController/StatefulViewControllerImplementation.swift
@@ -23,7 +23,7 @@ extension StatefulViewController {
     
     public var stateMachine: ViewStateMachine {
         return associatedObject(self, key: &stateMachineKey) { [unowned self] in
-            return ViewStateMachine(view: self.backingView)
+            return ViewStateMachine(view: self.backingView, insets: self.stateInsets)
         }
     }
     
@@ -58,7 +58,12 @@ extension StatefulViewController {
         get { return placeholderView(.Empty) }
         set { setPlaceholderView(newValue, forState: .Empty) }
     }
-    
+
+    public var stateInsets: UIEdgeInsets {
+        get { return UIEdgeInsetsZero }
+        set { stateMachine.insets = newValue }
+    }
+
     
     // MARK: Transitions
     

--- a/StatefulViewController/StatefulViewControllerImplementation.swift
+++ b/StatefulViewController/StatefulViewControllerImplementation.swift
@@ -60,14 +60,14 @@ extension StatefulViewController {
     }
 
     public var stateInsets: UIEdgeInsets {
-        get { return UIEdgeInsetsZero }
-        set { stateMachine.insets = newValue }
+        return UIEdgeInsetsZero
     }
 
     
     // MARK: Transitions
     
     public func setupInitialViewState() {
+        stateMachine.insets = stateInsets
         let isLoading = (lastState == .Loading)
         let error: NSError? = (lastState == .Error) ? NSError(domain: "com.aschuch.StatefulViewController.ErrorDomain", code: -1, userInfo: nil) : nil
         transitionViewStates(isLoading, error: error, animated: false)


### PR DESCRIPTION
I have had the issue of content not being properly displayed due to the fact that `self.view`s most of the time covered by either `UINavigationBar`s or `UITabBar`s.

As such I added a new property `stateInsets` to the `StatefulViewController` protocol to work around this particular issue. The implementation will also pass the insets onto the `ViewStateMachine` to set the constraints properly.