### PR TITLE
Make it possible to always show loadingView

### DIFF
--- a/StatefulViewController/StatefulViewController.swift
+++ b/StatefulViewController/StatefulViewController.swift
@@ -75,6 +75,11 @@ public protocol StatefulViewController: class, BackingViewProvider {
     
     // MARK: Content and error handling
     
+    /// A `Bool` that controls wether the `loadingView` should be shown when 
+    /// `hasContent` returns `true`.
+    /// - note: Default value is `false`
+    var alwaysShowLoadingView: Bool { get set }
+    
     /// Return true if content is available in your controller.
     ///
     /// - returns: true if there is content available in your controller.

--- a/StatefulViewController/StatefulViewControllerImplementation.swift
+++ b/StatefulViewController/StatefulViewControllerImplementation.swift
@@ -77,6 +77,11 @@ extension StatefulViewController {
     }
     
     public func transitionViewStates(loading: Bool = false, error: ErrorType? = nil, animated: Bool = true, completion: (() -> Void)? = nil) {
+        if loading && alwaysShowLoadingView {
+            self.stateMachine.transitionToState(.View(StatefulViewControllerState.Loading.rawValue), animated: animated, completion: completion)
+            return
+        }
+        
         // Update view for content (i.e. hide all placeholder views)
         if hasContent() {
             if let e = error {

--- a/StatefulViewController/StatefulViewControllerImplementation.swift
+++ b/StatefulViewController/StatefulViewControllerImplementation.swift
@@ -125,6 +125,13 @@ extension StatefulViewController {
 
 private var stateMachineKey: UInt8 = 0
 
+final class Associated<T> {
+    let value: T
+    init(_ x: T) {
+        value = x
+    }
+}
+
 private func associatedObject<T: AnyObject>(host: AnyObject, key: UnsafePointer<Void>, initial: () -> T) -> T {
     var value = objc_getAssociatedObject(host, key) as? T
     if value == nil {
@@ -132,4 +139,25 @@ private func associatedObject<T: AnyObject>(host: AnyObject, key: UnsafePointer<
         objc_setAssociatedObject(host, key, value, .OBJC_ASSOCIATION_RETAIN)
     }
     return value!
+}
+
+func setAssociatedObject<T>(object: AnyObject, value: T, associativeKey: UnsafePointer<Void>, policy: objc_AssociationPolicy) {
+    if let v: AnyObject = value as? AnyObject {
+        objc_setAssociatedObject(object, associativeKey, v,  policy)
+    }
+    else {
+        objc_setAssociatedObject(object, associativeKey, Associated(value),  policy)
+    }
+}
+
+func getAssociatedObject<T>(object: AnyObject, associativeKey: UnsafePointer<Void>) -> T? {
+    if let v = objc_getAssociatedObject(object, associativeKey) as? T {
+        return v
+    }
+    else if let v = objc_getAssociatedObject(object, associativeKey) as? Associated<T> {
+        return v.value
+    }
+    else {
+        return nil
+    }
 }

--- a/StatefulViewController/StatefulViewControllerImplementation.swift
+++ b/StatefulViewController/StatefulViewControllerImplementation.swift
@@ -133,6 +133,7 @@ extension StatefulViewController {
 // MARK: Association
 
 private var stateMachineKey: UInt8 = 0
+private var alwaysShowLoadingViewKey: UInt8 = 1
 
 final class Associated<T> {
     let value: T

--- a/StatefulViewController/StatefulViewControllerImplementation.swift
+++ b/StatefulViewController/StatefulViewControllerImplementation.swift
@@ -100,6 +100,15 @@ extension StatefulViewController {
     
     // MARK: Content and error handling
     
+    public var alwaysShowLoadingView: Bool {
+        get {
+            return getAssociatedObject(self, associativeKey: &alwaysShowLoadingViewKey) ?? false
+        }
+        set {
+            setAssociatedObject(self, value: newValue, associativeKey: &alwaysShowLoadingViewKey, policy: .OBJC_ASSOCIATION_RETAIN)
+        }
+    }
+    
     public func hasContent() -> Bool {
         return true
     }


### PR DESCRIPTION
For `UITableViewControllers` or actually any other view controllers that display content that is fetched from the network **StatefulViewController** is great already. 

In my project I have some different ones. In my login and registration flow I want to use **StatefulViewController** to display loading indicators. However, overriding `hasContent` is unlogical for those view controllers as they always show the same buttons and textfields that are static. I could just override `hasContent` and return `false`, but that seems wrong to me as in reality my view controllers **do** have content (the forms and buttons).

I added a new property to `StatefulViewController` and `StatefulViewControllerImplementation` named `alwaysShowLoadingView`. The default for this property if false, so everything behaves as before. When the property is set to `true` the loading view will be displayed regardless the return value of `hasContent`.