### PR TITLE
Added completion handler to setupInitialViewState

### DIFF
--- a/StatefulViewController/StatefulViewController.swift
+++ b/StatefulViewController/StatefulViewController.swift
@@ -48,7 +48,7 @@ public protocol StatefulViewController: class, BackingViewProvider {
     /// Sets up the initial state of the view.
     /// This method should be called as soon as possible in a view or view controller's
     /// life cycle, e.g. `viewWillAppear:`, to transition to the appropriate state.
-    func setupInitialViewState()
+    func setupInitialViewState(completion: (() -> Void)?)
     
     /// Transitions the controller to the loading state and shows
     /// the loading view if there is no content shown already.

--- a/StatefulViewController/StatefulViewControllerImplementation.swift
+++ b/StatefulViewController/StatefulViewControllerImplementation.swift
@@ -62,10 +62,10 @@ extension StatefulViewController {
     
     // MARK: Transitions
     
-    public func setupInitialViewState() {
+    public func setupInitialViewState(completion: (() -> Void)? = nil) {
         let isLoading = (lastState == .Loading)
         let error: NSError? = (lastState == .Error) ? NSError(domain: "com.aschuch.StatefulViewController.ErrorDomain", code: -1, userInfo: nil) : nil
-        transitionViewStates(isLoading, error: error, animated: false)
+        transitionViewStates(isLoading, error: error, animated: false, completion: completion)
     }
     
     public func startLoading(animated: Bool = false, completion: (() -> Void)? = nil) {


### PR DESCRIPTION
Useful when you need to bring a subview to front after initial setup.

For my case, I have a 'add' button on top of the view controller, so I have to perform bringSubviewToFront(myButton) after each stateFullViewController operation. startloading and endLoading both have their completion block param, I figured setupInitialViewState deserved one too.