### PR TITLE
Remove overlay between states animation

### DIFF
--- a/StatefulViewController/ViewStateMachine.swift
+++ b/StatefulViewController/ViewStateMachine.swift
@@ -164,6 +164,11 @@ public class ViewStateMachine {
             if let newView = self.viewStore[state] {
                 newView.alpha = 1.0
             }
+            for (key, view) in self.viewStore {
+                if !(key == state) {
+                    view.removeFromSuperview()
+                }
+            }
         }
         
         let animationCompletion: (Bool) -> () = { (finished) in


### PR DESCRIPTION
Moving between states offers animation where new view raises it's opacity, and an old view just stays the same. Then the old view is removed from superview in one flash.
I suggest adding animation from 1 to 0 for old views that are available in moving between states.

Before:
[Gif](http://recordit.co/W1kT888WPD)
After:
[Gif](http://recordit.co/KMxVHpQHFk)

Or you can suggest any other solution to this.