### PR TITLE
Make view property weak in ViewStateMachine to avoid retain cycle

### DIFF
--- a/StatefulViewController/ViewStateMachine.swift
+++ b/StatefulViewController/ViewStateMachine.swift
@@ -52,7 +52,7 @@ public class ViewStateMachine {
     }()
 
     /// The view that should act as the superview for any added views
-    public let view: UIView
+    public weak var view: UIView?
     
     /// The current display state of views
     public fileprivate(set) var currentState: ViewStateMachineState = .none
@@ -163,6 +163,9 @@ public class ViewStateMachine {
     
 	fileprivate func showView(forKey state: String, animated: Bool, completion: (() -> ())? = nil) {
         // Add the container view
+        guard let view = view else {
+            return
+        }
         containerView.frame = view.bounds
         view.addSubview(containerView)
 

--- a/StatefulViewController/ViewStateMachine.swift
+++ b/StatefulViewController/ViewStateMachine.swift
@@ -130,31 +130,18 @@ public class ViewStateMachine {
     public func transitionToState(_ state: ViewStateMachineState, animated: Bool = true, completion: (() -> ())? = nil) {
         lastState = state
         
-        queue.async { [weak self] in
-            guard let strongSelf = self else { return }
+        if state == currentState {
+            return
+        }
 
-            if state == strongSelf.currentState {
-                return
-            }
-            
-            // Suspend the queue, it will be resumed in the completion block
-            strongSelf.queue.suspend()
-            strongSelf.currentState = state
-            
-            let c: () -> () = {
-                strongSelf.queue.resume()
-                completion?()
-            }
-            
-            // Switch state and update the view
-            DispatchQueue.main.sync {
-                switch state {
-                case .none:
-                    strongSelf.hideAllViews(animated: animated, completion: c)
-                case .view(let viewKey):
-                    strongSelf.showView(forKey: viewKey, animated: animated, completion: c)
-                }
-            }
+        // Suspend the queue, it will be resumed in the completion block
+        currentState = state
+
+        switch state {
+        case .none:
+            hideAllViews(animated: animated, completion: completion)
+        case .view(let viewKey):
+            showView(forKey: viewKey, animated: animated, completion: completion)
         }
     }
     


### PR DESCRIPTION
Hi,

When using ViewStateMachine standalone like the following example, I experienced a retain cycle caused by the fact that ViewStateMachine hold a strong reference on the backed view.
Using a weak property fixed the problem.

```swift
class StateView: UIView {

    private var stateMachine: ViewStateMachine!
    private var loadingView: LoadingView!

    required init?(coder aDecoder: NSCoder) {
        super.init(coder: aDecoder)
        setupStateMachine()
    }

    override init(frame: CGRect) {
        super.init(frame: CGRect.zero)
        setupStateMachine()
    }

    private func setupStateMachine() {
        stateMachine = ViewStateMachine(view: self) // retain cycle
        loadingView = LoadingView(frame: self.bounds)
        stateMachine["loading"] = loadingView
    }

    func startLoading(_ message: String) {
        loadingView.label.text = message
        stateMachine.transitionToState(.view("loading"), animated: false, completion: nil)
    }

    ....
}
```